### PR TITLE
Added higher PWM frequency for Atmega2560

### DIFF
--- a/DualMC33926MotorShield.cpp
+++ b/DualMC33926MotorShield.cpp
@@ -148,16 +148,16 @@ void DualMC33926MotorShield::setSpeeds(int m1Speed, int m2Speed)
 unsigned int DualMC33926MotorShield::getM1CurrentMilliamps()
 {
   // 5V / 1024 ADC counts / 525 mV per A = 9 mA per count
-  // INTERNAL2V56 / 1024 ADC counts / 525 mV per A = 5 mA per count  
-  return analogRead(_M1FB) * 5;
+  // If using Internal2v56 reference, use: 2V56 / 1024 ADC counts / 525 mV per A = 5 mA per count  
+  return analogRead(_M1FB) * 9;
 }
 
 // Return motor 2 current value in milliamps.
 unsigned int DualMC33926MotorShield::getM2CurrentMilliamps()
 {
   // 5V / 1024 ADC counts / 525 mV per A = 9 mA per count
-  // INTERNAL2V56 / 1024 ADC counts / 525 mV per A = 5 mA per count  
-  return analogRead(_M2FB) * 5;
+  // If using Internal2v56 reference, use: 2V56 / 1024 ADC counts / 525 mV per A = 5 mA per count  
+  return analogRead(_M2FB) * 9;
 }
 
 // Return error status

--- a/DualMC33926MotorShield.cpp
+++ b/DualMC33926MotorShield.cpp
@@ -1,50 +1,167 @@
-#pragma once
+#include "DualMC33926MotorShield.h"
 
-#if defined(__AVR_ATmega168__) || defined(__AVR_ATmega328P__) || \
-    defined(__AVR_ATmega328PB__) || defined (__AVR_ATmega32U4__)
-  #define DUALMC33926MOTORSHIELD_TIMER1_AVAILABLE
-#endif
-#if defined(__AVR_ATmega2560__) 
-  #define DUALVNH5019MOTORSHIELD_TIMER2_AVAILABLE
-#endif
+// Constructors ////////////////////////////////////////////////////////////////
 
-
-#include <Arduino.h>
-
-class DualMC33926MotorShield
+DualMC33926MotorShield::DualMC33926MotorShield()
 {
-  public:
-    // CONSTRUCTORS
-    // Default pin selection.
-    DualMC33926MotorShield();
-    // User-defined pin selection.
-    DualMC33926MotorShield(unsigned char M1DIR,
-                           unsigned char M1PWM,
-                           unsigned char M1FB,
-                           unsigned char M2DIR,
-                           unsigned char M2PWM,
-                           unsigned char M2FB,
-                           unsigned char nD2,
-                           unsigned char nSF);
+  //Pin map
+  _nD2 = 4;
+  _M1DIR = 7;
+  _M1PWM = 9;
+  _M2DIR = 8;
+  _M2PWM = 10;
+  _nSF = 12;
+  _M1FB = A0;
+  _M2FB = A1;
+}
 
-    // PUBLIC METHODS
-    void init(); // Initialize TIMER 1, set the PWM to 20kHZ.
-    void setM1Speed(int speed); // Set speed for M1.
-    void setM2Speed(int speed); // Set speed for M2.
-    void setSpeeds(int m1Speed, int m2Speed); // Set speed for both M1 and M2.
-    unsigned int getM1CurrentMilliamps(); // Get current reading for M1.
-    unsigned int getM2CurrentMilliamps(); // Get current reading for M2.
-    unsigned char getFault(); // Get fault reading.
+DualMC33926MotorShield::DualMC33926MotorShield(unsigned char M1DIR,
+                                               unsigned char M1PWM,
+                                               unsigned char M1FB,
+                                               unsigned char M2DIR,
+                                               unsigned char M2PWM,
+                                               unsigned char M2FB,
+                                               unsigned char nD2,
+                                               unsigned char nSF)
+{
+  _nD2 = nD2;
+  _M1DIR = M1DIR;
+  _M1PWM = M1PWM;
+  _M2DIR = M2DIR;
+  _M2PWM = M2PWM;
+  _nSF = nSF;
+  _M1FB = M1FB;
+  _M2FB = M2FB;
+}
 
-  private:
-    unsigned char _nD2;
-    unsigned char _M1DIR;
-    unsigned char _M2DIR;
-    unsigned char _M1PWM;
-    static const unsigned char _M1PWM_TIMER1_PIN = 9;
-    unsigned char _M2PWM;
-    static const unsigned char _M2PWM_TIMER1_PIN = 10;
-    unsigned char _nSF;
-    unsigned char _M1FB;
-    unsigned char _M2FB;
-};
+// Public Methods //////////////////////////////////////////////////////////////
+void DualMC33926MotorShield::init()
+{
+// Define pinMode for the pins and set the frequency for timer1.
+
+  pinMode(_M1DIR,OUTPUT);
+  pinMode(_M1PWM,OUTPUT);
+  pinMode(_M1FB,INPUT);
+  pinMode(_M2DIR,OUTPUT);
+  pinMode(_M2PWM,OUTPUT);
+  pinMode(_M2FB,INPUT);
+  pinMode(_nD2,OUTPUT);
+  digitalWrite(_nD2,HIGH); // default to on
+  pinMode(_nSF,INPUT);
+
+  #ifdef DUALMC33926MOTORSHIELD_TIMER1_AVAILABLE
+    if (_M1PWM == _M1PWM_TIMER1_PIN && _M2PWM == _M2PWM_TIMER1_PIN)
+    {
+      // Timer 1 configuration
+      // prescaler: clockI/O / 1
+      // outputs enabled
+      // phase-correct PWM
+      // top of 400
+      //
+      // PWM frequency calculation
+      // 16MHz / 1 (prescaler) / 2 (phase-correct) / 400 (top) = 20kHz
+      TCCR1A = 0b10100000;
+      TCCR1B = 0b00010001;
+      ICR1 = 400;
+    }
+  #endif
+    #ifdef DUALVNH5019MOTORSHIELD_TIMER2_AVAILABLE
+    if (_M1PWM == _M1PWM_TIMER1_PIN && _M2PWM == _M2PWM_TIMER1_PIN)
+    {
+      TCCR2B &= ~ _BV (CS22); // cancel pre-scaler of 64
+      TCCR2B |= _BV (CS20);   // no pre-scaler
+    }
+  #endif
+}
+// Set speed for motor 1, speed is a number betwenn -400 and 400
+void DualMC33926MotorShield::setM1Speed(int speed)
+{
+  unsigned char reverse = 0;
+
+  if (speed < 0)
+  {
+    speed = -speed;  // Make speed a positive quantity
+    reverse = 1;  // Preserve the direction
+  }
+  if (speed > 400)  // Max PWM dutycycle
+    speed = 400;
+
+  #ifdef DUALMC33926MOTORSHIELD_TIMER1_AVAILABLE
+    if (_M1PWM == _M1PWM_TIMER1_PIN && _M2PWM == _M2PWM_TIMER1_PIN)
+    {
+      OCR1A = speed;
+    }
+    else
+    {
+      analogWrite(_M1PWM,speed * 51 / 80); // map 400 to 255
+    }
+  #else
+    analogWrite(_M1PWM,speed * 51 / 80); // map 400 to 255
+  #endif
+
+  if (reverse)
+    digitalWrite(_M1DIR,HIGH);
+  else
+    digitalWrite(_M1DIR,LOW);
+}
+
+// Set speed for motor 2, speed is a number betwenn -400 and 400
+void DualMC33926MotorShield::setM2Speed(int speed)
+{
+  unsigned char reverse = 0;
+
+  if (speed < 0)
+  {
+    speed = -speed;  // Make speed a positive quantity
+    reverse = 1;  // Preserve the direction
+  }
+  if (speed > 400)  // Max PWM dutycycle
+    speed = 400;
+
+  #ifdef DUALMC33926MOTORSHIELD_TIMER1_AVAILABLE
+    if (_M1PWM == _M1PWM_TIMER1_PIN && _M2PWM == _M2PWM_TIMER1_PIN)
+    {
+      OCR1B = speed;
+    }
+    else
+    {
+      analogWrite(_M2PWM,speed * 51 / 80); // map 400 to 255
+    }
+  #else
+    analogWrite(_M2PWM,speed * 51 / 80); // map 400 to 255
+  #endif
+
+  if (reverse)
+    digitalWrite(_M2DIR,HIGH);
+  else
+    digitalWrite(_M2DIR,LOW);
+}
+
+// Set speed for motor 1 and 2
+void DualMC33926MotorShield::setSpeeds(int m1Speed, int m2Speed)
+{
+  setM1Speed(m1Speed);
+  setM2Speed(m2Speed);
+}
+
+// Return motor 1 current value in milliamps.
+unsigned int DualMC33926MotorShield::getM1CurrentMilliamps()
+{
+  // 5V / 1024 ADC counts / 525 mV per A = 9 mA per count
+  // INTERNAL2V56 / 1024 ADC counts / 525 mV per A = 5 mA per count  
+  return analogRead(_M1FB) * 5;
+}
+
+// Return motor 2 current value in milliamps.
+unsigned int DualMC33926MotorShield::getM2CurrentMilliamps()
+{
+  // 5V / 1024 ADC counts / 525 mV per A = 9 mA per count
+  // INTERNAL2V56 / 1024 ADC counts / 525 mV per A = 5 mA per count  
+  return analogRead(_M2FB) * 5;
+}
+
+// Return error status
+unsigned char DualMC33926MotorShield::getFault()
+{
+  return !digitalRead(_nSF);
+}

--- a/DualMC33926MotorShield.cpp
+++ b/DualMC33926MotorShield.cpp
@@ -1,158 +1,50 @@
-#include "DualMC33926MotorShield.h"
+#pragma once
 
-// Constructors ////////////////////////////////////////////////////////////////
+#if defined(__AVR_ATmega168__) || defined(__AVR_ATmega328P__) || \
+    defined(__AVR_ATmega328PB__) || defined (__AVR_ATmega32U4__)
+  #define DUALMC33926MOTORSHIELD_TIMER1_AVAILABLE
+#endif
+#if defined(__AVR_ATmega2560__) 
+  #define DUALVNH5019MOTORSHIELD_TIMER2_AVAILABLE
+#endif
 
-DualMC33926MotorShield::DualMC33926MotorShield()
+
+#include <Arduino.h>
+
+class DualMC33926MotorShield
 {
-  //Pin map
-  _nD2 = 4;
-  _M1DIR = 7;
-  _M1PWM = 9;
-  _M2DIR = 8;
-  _M2PWM = 10;
-  _nSF = 12;
-  _M1FB = A0;
-  _M2FB = A1;
-}
+  public:
+    // CONSTRUCTORS
+    // Default pin selection.
+    DualMC33926MotorShield();
+    // User-defined pin selection.
+    DualMC33926MotorShield(unsigned char M1DIR,
+                           unsigned char M1PWM,
+                           unsigned char M1FB,
+                           unsigned char M2DIR,
+                           unsigned char M2PWM,
+                           unsigned char M2FB,
+                           unsigned char nD2,
+                           unsigned char nSF);
 
-DualMC33926MotorShield::DualMC33926MotorShield(unsigned char M1DIR,
-                                               unsigned char M1PWM,
-                                               unsigned char M1FB,
-                                               unsigned char M2DIR,
-                                               unsigned char M2PWM,
-                                               unsigned char M2FB,
-                                               unsigned char nD2,
-                                               unsigned char nSF)
-{
-  _nD2 = nD2;
-  _M1DIR = M1DIR;
-  _M1PWM = M1PWM;
-  _M2DIR = M2DIR;
-  _M2PWM = M2PWM;
-  _nSF = nSF;
-  _M1FB = M1FB;
-  _M2FB = M2FB;
-}
+    // PUBLIC METHODS
+    void init(); // Initialize TIMER 1, set the PWM to 20kHZ.
+    void setM1Speed(int speed); // Set speed for M1.
+    void setM2Speed(int speed); // Set speed for M2.
+    void setSpeeds(int m1Speed, int m2Speed); // Set speed for both M1 and M2.
+    unsigned int getM1CurrentMilliamps(); // Get current reading for M1.
+    unsigned int getM2CurrentMilliamps(); // Get current reading for M2.
+    unsigned char getFault(); // Get fault reading.
 
-// Public Methods //////////////////////////////////////////////////////////////
-void DualMC33926MotorShield::init()
-{
-// Define pinMode for the pins and set the frequency for timer1.
-
-  pinMode(_M1DIR,OUTPUT);
-  pinMode(_M1PWM,OUTPUT);
-  pinMode(_M1FB,INPUT);
-  pinMode(_M2DIR,OUTPUT);
-  pinMode(_M2PWM,OUTPUT);
-  pinMode(_M2FB,INPUT);
-  pinMode(_nD2,OUTPUT);
-  digitalWrite(_nD2,HIGH); // default to on
-  pinMode(_nSF,INPUT);
-
-  #ifdef DUALMC33926MOTORSHIELD_TIMER1_AVAILABLE
-    if (_M1PWM == _M1PWM_TIMER1_PIN && _M2PWM == _M2PWM_TIMER1_PIN)
-    {
-      // Timer 1 configuration
-      // prescaler: clockI/O / 1
-      // outputs enabled
-      // phase-correct PWM
-      // top of 400
-      //
-      // PWM frequency calculation
-      // 16MHz / 1 (prescaler) / 2 (phase-correct) / 400 (top) = 20kHz
-      TCCR1A = 0b10100000;
-      TCCR1B = 0b00010001;
-      ICR1 = 400;
-    }
-  #endif
-}
-// Set speed for motor 1, speed is a number betwenn -400 and 400
-void DualMC33926MotorShield::setM1Speed(int speed)
-{
-  unsigned char reverse = 0;
-
-  if (speed < 0)
-  {
-    speed = -speed;  // Make speed a positive quantity
-    reverse = 1;  // Preserve the direction
-  }
-  if (speed > 400)  // Max PWM dutycycle
-    speed = 400;
-
-  #ifdef DUALMC33926MOTORSHIELD_TIMER1_AVAILABLE
-    if (_M1PWM == _M1PWM_TIMER1_PIN && _M2PWM == _M2PWM_TIMER1_PIN)
-    {
-      OCR1A = speed;
-    }
-    else
-    {
-      analogWrite(_M1PWM,speed * 51 / 80); // map 400 to 255
-    }
-  #else
-    analogWrite(_M1PWM,speed * 51 / 80); // map 400 to 255
-  #endif
-
-  if (reverse)
-    digitalWrite(_M1DIR,HIGH);
-  else
-    digitalWrite(_M1DIR,LOW);
-}
-
-// Set speed for motor 2, speed is a number betwenn -400 and 400
-void DualMC33926MotorShield::setM2Speed(int speed)
-{
-  unsigned char reverse = 0;
-
-  if (speed < 0)
-  {
-    speed = -speed;  // Make speed a positive quantity
-    reverse = 1;  // Preserve the direction
-  }
-  if (speed > 400)  // Max PWM dutycycle
-    speed = 400;
-
-  #ifdef DUALMC33926MOTORSHIELD_TIMER1_AVAILABLE
-    if (_M1PWM == _M1PWM_TIMER1_PIN && _M2PWM == _M2PWM_TIMER1_PIN)
-    {
-      OCR1B = speed;
-    }
-    else
-    {
-      analogWrite(_M2PWM,speed * 51 / 80); // map 400 to 255
-    }
-  #else
-    analogWrite(_M2PWM,speed * 51 / 80); // map 400 to 255
-  #endif
-
-  if (reverse)
-    digitalWrite(_M2DIR,HIGH);
-  else
-    digitalWrite(_M2DIR,LOW);
-}
-
-// Set speed for motor 1 and 2
-void DualMC33926MotorShield::setSpeeds(int m1Speed, int m2Speed)
-{
-  setM1Speed(m1Speed);
-  setM2Speed(m2Speed);
-}
-
-// Return motor 1 current value in milliamps.
-unsigned int DualMC33926MotorShield::getM1CurrentMilliamps()
-{
-  // 5V / 1024 ADC counts / 525 mV per A = 9 mA per count
-  return analogRead(_M1FB) * 9;
-}
-
-// Return motor 2 current value in milliamps.
-unsigned int DualMC33926MotorShield::getM2CurrentMilliamps()
-{
-  // 5V / 1024 ADC counts / 525 mV per A = 9 mA per count
-  return analogRead(_M2FB) * 9;
-}
-
-// Return error status
-unsigned char DualMC33926MotorShield::getFault()
-{
-  return !digitalRead(_nSF);
-}
+  private:
+    unsigned char _nD2;
+    unsigned char _M1DIR;
+    unsigned char _M2DIR;
+    unsigned char _M1PWM;
+    static const unsigned char _M1PWM_TIMER1_PIN = 9;
+    unsigned char _M2PWM;
+    static const unsigned char _M2PWM_TIMER1_PIN = 10;
+    unsigned char _nSF;
+    unsigned char _M1FB;
+    unsigned char _M2FB;
+};

--- a/DualMC33926MotorShield.h
+++ b/DualMC33926MotorShield.h
@@ -4,6 +4,10 @@
     defined(__AVR_ATmega328PB__) || defined (__AVR_ATmega32U4__)
   #define DUALMC33926MOTORSHIELD_TIMER1_AVAILABLE
 #endif
+#if defined(__AVR_ATmega2560__) 
+  #define DUALVNH5019MOTORSHIELD_TIMER2_AVAILABLE
+#endif
+
 
 #include <Arduino.h>
 


### PR DESCRIPTION
I've added an implementation using Timer2 on the Atmega2560 to do the PWM'ing of the motors.
This prevents having to use the standard, low PWM frequency of the Arduino, and thus preventing inaccurate current measurements and noisy motors. 